### PR TITLE
Fix link to Advanced Modern Algebra

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Mathematical Literacy
 ### Algebra
 
   - [A Computational Introduction to Number Theory and Algebra](http://shoup.net/ntb/) — Victor Shroup
-  - Advanced Modern Algebra — Joseph J. Rotman [pdf](https://drive.google.com/file/d/0B4VsXmbvS2WjYmI1ODVkNDctY2NiNi00M2I2LTkzYzktODAxNjQ2MWM5MTkz/view?ddrp=1&hl=en&pli=1#)
+  - Advanced Modern Algebra — Joseph J. Rotman [pdf](https://drive.google.com/file/d/0B4VsXmbvS2WjYmI1ODVkNDctY2NiNi00M2I2LTkzYzktODAxNjQ2MWM5MTkz/view?ddrp=1&hl=en&pli=1)
   - A Survey of Modern Algebra — Birkhoff and MacLane [Scribd](https://www.scribd.com/doc/198868558/A-Survey-of-Modern-Algebra-Birkhoff-MacLane#scribd)
 
 

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Mathematical Literacy
 ### Algebra
 
   - [A Computational Introduction to Number Theory and Algebra](http://shoup.net/ntb/) — Victor Shroup
-  - Advanced Modern Algebra — Joseph J. Rotman [pdf](http://www.math.hcmuns.edu.vn/~nvdong/DaiSoDaiCuong/Advanced%20Modern%20Algebra%20-%20Joseph%20J.%20Rotman.pdf)
+  - Advanced Modern Algebra — Joseph J. Rotman [pdf](https://drive.google.com/file/d/0B4VsXmbvS2WjYmI1ODVkNDctY2NiNi00M2I2LTkzYzktODAxNjQ2MWM5MTkz/view?ddrp=1&hl=en&pli=1#)
   - A Survey of Modern Algebra — Birkhoff and MacLane [Scribd](https://www.scribd.com/doc/198868558/A-Survey-of-Modern-Algebra-Birkhoff-MacLane#scribd)
 
 


### PR DESCRIPTION
The link appears to have been removed so I've switched it with an alternate.

I can't vouch for the longevity of the new link but there are other possible mirrors found with a quick search, eg: http://download.bioon.com.cn/upload/201302/07042642_6734.pdf

Anyhow, fantastic work on the list!