### PR TITLE
Remove unavailable video resource

### DIFF
--- a/index.md
+++ b/index.md
@@ -130,10 +130,6 @@ Compiler Construction
   - [ZINC](http://caml.inria.fr/pub/papers/xleroy-zinc.pdf) - The ZINC experiment, an economical implementation of the ML language - Xavier Leroy (Technical Report) [more OCaml papers](http://caml.inria.fr/about/papers.en.html)
 
 
-### Videos
-  - [Coursera - Stanford - Compilers](http://www.coursera.org/course/compilers) - Alex Aiken
-
-
 
 Runtime systems
 ---------------


### PR DESCRIPTION
The course isn't available on Coursera anymore. I tried to search for other courses about compilers but [didn't find any](https://www.coursera.org/courses?languages=en&query=compilers).